### PR TITLE
BLD Add compiler args for C++11

### DIFF
--- a/sklearn/metrics/setup.py
+++ b/sklearn/metrics/setup.py
@@ -32,6 +32,7 @@ def configuration(parent_package="", top_path=None):
         include_dirs=[np.get_include(), os.path.join(np.get_include(), "numpy")],
         language="c++",
         libraries=libraries,
+        extra_compile_args=["-std=c++11"],
     )
 
     config.add_subpackage("tests")


### PR DESCRIPTION
My system requires the c++11 flag to used shared pointers.

CC @jjerphan 